### PR TITLE
feat: persist checkout orders before whatsapp

### DIFF
--- a/src/components/CartSheet.tsx
+++ b/src/components/CartSheet.tsx
@@ -11,7 +11,8 @@ export interface CartSheetProps {
   onClose: () => void;
   onIncrement: (key: string) => void;
   onDecrement: (key: string) => void;
-  onCheckout: () => void;
+  onCheckout: () => void | Promise<void>;
+  isProcessingCheckout?: boolean;
 }
 
 const CartSheet: FC<CartSheetProps> = ({
@@ -22,8 +23,11 @@ const CartSheet: FC<CartSheetProps> = ({
   onIncrement,
   onDecrement,
   onCheckout,
+  isProcessingCheckout = false,
 }) => {
   const sheetClassName = `${styles.sheet} ${isOpen ? styles.open : ''}`.trim();
+  const checkoutDisabled = totals.count === 0 || isProcessingCheckout;
+  const checkoutTotal = formatCurrency(totals.total);
 
   return (
     <section className={sheetClassName} aria-hidden={!isOpen}>
@@ -65,10 +69,17 @@ const CartSheet: FC<CartSheetProps> = ({
         <button
           type="button"
           className={styles.checkout}
-          disabled={totals.count === 0}
+          disabled={checkoutDisabled}
+          aria-busy={isProcessingCheckout}
           onClick={onCheckout}
         >
-          Finalizar • <span>{formatCurrency(totals.total)}</span>
+          {isProcessingCheckout ? (
+            <span>Enviando...</span>
+          ) : (
+            <>
+              Finalizar • <span>{checkoutTotal}</span>
+            </>
+          )}
         </button>
       </div>
     </section>

--- a/src/services/OrderRepository.ts
+++ b/src/services/OrderRepository.ts
@@ -1,0 +1,106 @@
+import type { OrderRequest, OrderResponse } from '../types/order';
+
+export interface OrderRepositoryOptions {
+  endpoint?: string;
+  queueEndpoint?: string | null;
+}
+
+const DEFAULT_ENDPOINT: string =
+  typeof import.meta !== 'undefined' && import.meta.env?.VITE_ORDERS_ENDPOINT
+    ? import.meta.env.VITE_ORDERS_ENDPOINT
+    : '/api/orders';
+
+const DEFAULT_QUEUE_ENDPOINT: string | undefined =
+  typeof import.meta !== 'undefined' && import.meta.env?.VITE_ORDERS_QUEUE_ENDPOINT
+    ? import.meta.env.VITE_ORDERS_QUEUE_ENDPOINT
+    : undefined;
+
+export class OrderRepository {
+  private readonly endpoint: string;
+
+  private readonly queueEndpoint?: string;
+
+  public constructor(options: OrderRepositoryOptions = {}) {
+    this.endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
+    this.queueEndpoint = options.queueEndpoint ?? DEFAULT_QUEUE_ENDPOINT ?? undefined;
+  }
+
+  public async create(order: OrderRequest): Promise<OrderResponse> {
+    if (this.queueEndpoint) {
+      return this.enqueue(order);
+    }
+
+    return this.persist(order);
+  }
+
+  private async persist(order: OrderRequest): Promise<OrderResponse> {
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(order),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Falha ao registrar pedido: ${response.status} ${errorText || response.statusText}`.trim(),
+      );
+    }
+
+    const parsed = await this.tryParseJson<OrderResponse>(response);
+    return parsed ?? this.createFallbackResponse(order);
+  }
+
+  private async enqueue(order: OrderRequest): Promise<OrderResponse> {
+    if (!this.queueEndpoint) {
+      return this.persist(order);
+    }
+
+    const response = await fetch(this.queueEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(order),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Falha ao enfileirar pedido: ${response.status} ${errorText || response.statusText}`.trim(),
+      );
+    }
+
+    const parsed = await this.tryParseJson<OrderResponse>(response);
+    return parsed ?? this.createFallbackResponse(order, { status: 'queued' });
+  }
+
+  private async tryParseJson<T>(response: Response): Promise<T | null> {
+    try {
+      return (await response.clone().json()) as T;
+    } catch (error) {
+      console.warn('Resposta sem JSON estruturado para pedido.', error);
+      return null;
+    }
+  }
+
+  private createFallbackResponse(
+    order: OrderRequest,
+    overrides: Partial<OrderResponse> = {},
+  ): OrderResponse {
+    const generatedId = `temp-${Date.now()}`;
+
+    return {
+      id: overrides.id ?? generatedId,
+      status: overrides.status ?? order.status,
+      customer: overrides.customer ?? order.customer,
+      items: overrides.items ?? order.items,
+      totals: overrides.totals ?? order.totals,
+      address: overrides.address ?? order.address,
+      createdAt: overrides.createdAt ?? new Date().toISOString(),
+      metadata: overrides.metadata ?? order.metadata,
+    };
+  }
+}

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,0 +1,56 @@
+import type { CartLine, CartSelection, CartTotals } from './menu';
+
+export type OrderStatus = 'pending' | 'queued' | 'confirmed' | 'failed';
+
+export interface OrderCustomer {
+  name: string;
+  phone: string;
+  notes?: string;
+}
+
+export interface OrderAddress {
+  label: string;
+  latitude?: number;
+  longitude?: number;
+  complement?: string;
+}
+
+export interface OrderItem {
+  lineId: string;
+  productId: string;
+  name: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+  selection: CartSelection;
+}
+
+export interface OrderRequest {
+  customer: OrderCustomer;
+  items: OrderItem[];
+  totals: CartTotals;
+  address: OrderAddress;
+  status: OrderStatus;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OrderResponse {
+  id: string;
+  status: OrderStatus;
+  customer: OrderCustomer;
+  items: OrderItem[];
+  totals: CartTotals;
+  address: OrderAddress;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export const mapCartLineToOrderItem = (line: CartLine): OrderItem => ({
+  lineId: line.key,
+  productId: line.product.id,
+  name: line.product.name,
+  quantity: line.quantity,
+  unitPrice: line.unitPrice,
+  totalPrice: line.unitPrice * line.quantity,
+  selection: line.selection,
+});


### PR DESCRIPTION
## Summary
- define strong typed order request/response contracts to describe customer data, items, totals, address and status
- add an OrderRepository service with HTTP/queue support to persist orders before messaging
- update checkout UI to await persistence, show busy state, and include the order reference in the WhatsApp message

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d09d27d7208330ba0561fda267cbc0