### PR TITLE
Add admin dashboard with order management workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "pizzaria",
       "version": "0.0.0",
       "dependencies": {
+        "@types/react-router-dom": "^5.3.3",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -1616,6 +1618,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1627,7 +1635,6 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1641,6 +1648,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2320,6 +2348,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2353,7 +2390,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3600,6 +3636,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
+      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.1.tgz",
+      "integrity": "sha512-U9WBQssBE9B1vmRjo9qTM7YRzfZ3lUxESIZnsf4VjR/lXYz9MHjvOxHzr/aUm4efpktbVOrF09rL/y4VHa8RMw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3729,6 +3803,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^5.0.2",
     "eslint": "^9.35.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/admin/AdminLogin.tsx
+++ b/src/admin/AdminLogin.tsx
@@ -1,0 +1,80 @@
+import type { ChangeEvent, FC, FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import type { Location } from 'react-router-dom';
+import { useAdminAuth } from './state/useAdminAuth';
+import styles from '../styles/admin/AdminLogin.module.css';
+
+const AdminLogin: FC = () => {
+  const { login, isAuthenticated } = useAdminAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [token, setToken] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const resolveRedirectTarget = (state: unknown): string => {
+    if (state && typeof state === 'object' && 'from' in state) {
+      const fromLocation = (state as { from?: Location }).from;
+      if (fromLocation && typeof fromLocation.pathname === 'string') {
+        return fromLocation.pathname;
+      }
+    }
+    return '/admin';
+  };
+
+  useEffect((): void => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const redirectTarget = resolveRedirectTarget(location.state);
+    navigate(redirectTarget, { replace: true });
+  }, [isAuthenticated, location.state, navigate]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setToken(event.target.value);
+    if (error) {
+      setError(null);
+    }
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const success = login(token);
+    if (!success) {
+      setError('Token inválido. Tente novamente.');
+      return;
+    }
+    const redirectTarget = resolveRedirectTarget(location.state);
+    navigate(redirectTarget, { replace: true });
+  };
+
+  return (
+    <main className={styles.wrapper}>
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <h1 className={styles.title}>Acesso administrativo</h1>
+        <p className={styles.subtitle}>Informe o token de administrador para entrar.</p>
+        <label className={styles.label} htmlFor="admin-token">
+          Token de acesso
+        </label>
+        <input
+          id="admin-token"
+          name="token"
+          type="password"
+          className={styles.input}
+          value={token}
+          onChange={handleChange}
+          placeholder="Digite o token fornecido"
+          autoComplete="current-password"
+          required
+        />
+        {error ? <p className={styles.error}>{error}</p> : null}
+        <button type="submit" className={styles.submit}>
+          Entrar
+        </button>
+      </form>
+    </main>
+  );
+};
+
+export default AdminLogin;

--- a/src/admin/AdminProtectedRoute.tsx
+++ b/src/admin/AdminProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import type { FC, ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAdminAuth } from './state/useAdminAuth';
+
+interface AdminProtectedRouteProps {
+  children: ReactNode;
+}
+
+const AdminProtectedRoute: FC<AdminProtectedRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAdminAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/admin/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminProtectedRoute;

--- a/src/admin/Dashboard.tsx
+++ b/src/admin/Dashboard.tsx
@@ -1,0 +1,86 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import OrderDetails from './components/OrderDetails';
+import OrderList from './components/OrderList';
+import { OrderQueueProvider } from './state/OrderQueueProvider';
+import { useOrderQueue } from './state/useOrderQueue';
+import { OrderCommandService } from '../services/OrderCommandService';
+import { OrderRepository } from '../services/OrderRepository';
+import styles from '../styles/admin/Dashboard.module.css';
+
+const DashboardContent: FC = () => {
+  const {
+    orders,
+    selectedOrder,
+    selectedOrderId,
+    isLoading,
+    isProcessing,
+    processingOrderId,
+    error,
+    refresh,
+    selectOrder,
+    accept,
+    discard,
+  } = useOrderQueue();
+
+  const handleRefresh = async (): Promise<void> => {
+    await refresh();
+  };
+
+  const handleSelect = (orderId: string): void => {
+    selectOrder(orderId);
+  };
+
+  const handleAccept = async (orderId: string): Promise<void> => {
+    await accept(orderId);
+  };
+
+  const handleDiscard = async (orderId: string): Promise<void> => {
+    await discard(orderId);
+  };
+
+  return (
+    <div className={styles.dashboard}>
+      <header className={styles.header}>
+        <div className={styles.headingGroup}>
+          <h1 className={styles.title}>Painel administrativo</h1>
+          <p className={styles.subtitle}>Gerencie a fila de pedidos com rapidez.</p>
+        </div>
+      </header>
+      {error ? <p className={styles.error}>{error}</p> : null}
+      <div className={styles.columns}>
+        <OrderList
+          orders={orders}
+          selectedOrderId={selectedOrderId}
+          isLoading={isLoading}
+          processingOrderId={processingOrderId}
+          onSelect={handleSelect}
+          onRefresh={handleRefresh}
+        />
+        <OrderDetails
+          order={selectedOrder}
+          isProcessing={isProcessing}
+          processingOrderId={processingOrderId}
+          onAccept={handleAccept}
+          onDiscard={handleDiscard}
+        />
+      </div>
+    </div>
+  );
+};
+
+const Dashboard: FC = () => {
+  const repository = useMemo<OrderRepository>(() => new OrderRepository(), []);
+  const commandService = useMemo<OrderCommandService>(
+    () => new OrderCommandService({ repository }),
+    [repository],
+  );
+
+  return (
+    <OrderQueueProvider repository={repository} commandService={commandService}>
+      <DashboardContent />
+    </OrderQueueProvider>
+  );
+};
+
+export default Dashboard;

--- a/src/admin/components/OrderDetails.tsx
+++ b/src/admin/components/OrderDetails.tsx
@@ -1,0 +1,145 @@
+import type { FC } from 'react';
+import type { OrderItem, OrderResponse, OrderStatus } from '../../types/order';
+import { formatCurrency } from '../../utils/format';
+import styles from '../../styles/admin/OrderDetails.module.css';
+
+interface OrderDetailsProps {
+  order: OrderResponse | null;
+  isProcessing: boolean;
+  processingOrderId: string | null;
+  onAccept(orderId: string): Promise<void>;
+  onDiscard(orderId: string): Promise<void>;
+}
+
+const getStatusLabel = (status: OrderStatus): string => {
+  switch (status) {
+    case 'pending':
+      return 'Pendente';
+    case 'queued':
+      return 'Na fila';
+    case 'confirmed':
+      return 'Confirmado';
+    case 'failed':
+      return 'Descartado';
+    default:
+      return status;
+  }
+};
+
+const formatSelection = (selection: OrderItem['selection']): string => {
+  const entries = Object.entries(selection);
+  if (entries.length === 0) {
+    return 'Sem adicionais';
+  }
+  return entries
+    .map(([group, value]) => {
+      if (Array.isArray(value)) {
+        return `${group}: ${value.join(', ')}`;
+      }
+      return `${group}: ${value}`;
+    })
+    .join(' • ');
+};
+
+const OrderDetails: FC<OrderDetailsProps> = ({
+  order,
+  isProcessing,
+  processingOrderId,
+  onAccept,
+  onDiscard,
+}) => {
+  if (!order) {
+    return (
+      <section className={styles.container} aria-label="Detalhes do pedido">
+        <div className={styles.placeholder}>
+          <h2>Nenhum pedido selecionado</h2>
+          <p>Escolha um pedido na lista para visualizar os detalhes.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const isBusy = isProcessing && processingOrderId === order.id;
+
+  const handleAccept = async (): Promise<void> => {
+    await onAccept(order.id);
+  };
+
+  const handleDiscard = async (): Promise<void> => {
+    await onDiscard(order.id);
+  };
+
+  return (
+    <section className={styles.container} aria-label={`Pedido ${order.id}`}>
+      <header className={styles.header}>
+        <div>
+          <h2 className={styles.title}>Pedido #{order.id}</h2>
+          <p className={styles.subtitle}>{order.customer.name}</p>
+        </div>
+        <span className={`${styles.status} ${styles[order.status]}`}>{getStatusLabel(order.status)}</span>
+      </header>
+
+      <div className={styles.section}>
+        <h3 className={styles.sectionTitle}>Contato</h3>
+        <p className={styles.sectionContent}>
+          {order.customer.phone}
+          {order.customer.notes ? <span className={styles.inlineNote}>• {order.customer.notes}</span> : null}
+        </p>
+      </div>
+
+      <div className={styles.section}>
+        <h3 className={styles.sectionTitle}>Entrega</h3>
+        <p className={styles.sectionContent}>{order.address.label}</p>
+        {order.address.complement ? (
+          <p className={styles.sectionContentMuted}>{order.address.complement}</p>
+        ) : null}
+      </div>
+
+      <div className={`${styles.section} ${styles.items}`}>
+        <h3 className={styles.sectionTitle}>Itens</h3>
+        <ul className={styles.itemsList}>
+          {order.items.map((item) => (
+            <li key={item.lineId} className={styles.item}>
+              <div className={styles.itemHeader}>
+                <span className={styles.itemName}>{item.name}</span>
+                <span className={styles.itemTotal}>{formatCurrency(item.totalPrice)}</span>
+              </div>
+              <div className={styles.itemMeta}>
+                <span className={styles.itemQuantity}>{item.quantity}x</span>
+                <span className={styles.itemSelection}>{formatSelection(item.selection)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.summaryRow}>
+          <span>Total</span>
+          <strong>{formatCurrency(order.totals.total)}</strong>
+        </div>
+      </div>
+
+      <footer className={styles.actions}>
+        <button
+          type="button"
+          className={styles.discard}
+          onClick={handleDiscard}
+          disabled={isBusy}
+        >
+          {isBusy ? 'Processando…' : 'Descartar'}
+        </button>
+        <button
+          type="button"
+          className={styles.accept}
+          onClick={handleAccept}
+          disabled={isBusy}
+        >
+          {isBusy ? 'Processando…' : 'Aceitar'}
+        </button>
+      </footer>
+    </section>
+  );
+};
+
+export default OrderDetails;

--- a/src/admin/components/OrderList.tsx
+++ b/src/admin/components/OrderList.tsx
@@ -1,0 +1,105 @@
+import type { FC } from 'react';
+import type { OrderResponse } from '../../types/order';
+import { formatCurrency } from '../../utils/format';
+import styles from '../../styles/admin/OrderList.module.css';
+
+interface OrderListProps {
+  orders: OrderResponse[];
+  selectedOrderId: string | null;
+  isLoading: boolean;
+  processingOrderId: string | null;
+  onSelect(orderId: string): void;
+  onRefresh(): Promise<void>;
+}
+
+const formatTimestamp = (timestamp: string): string => {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) {
+    return 'Data desconhecida';
+  }
+  return new Intl.DateTimeFormat('pt-BR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(parsed);
+};
+
+const OrderList: FC<OrderListProps> = ({
+  orders,
+  selectedOrderId,
+  isLoading,
+  processingOrderId,
+  onSelect,
+  onRefresh,
+}) => {
+  const handleSelect = (orderId: string): void => {
+    onSelect(orderId);
+  };
+
+  const handleRefresh = async (): Promise<void> => {
+    await onRefresh();
+  };
+
+  return (
+    <section className={styles.container} aria-label="Pedidos pendentes">
+      <header className={styles.header}>
+        <div>
+          <h2 className={styles.title}>Fila de pedidos</h2>
+          <p className={styles.caption}>
+            {orders.length > 0
+              ? `${orders.length} pedido${orders.length > 1 ? 's' : ''} em espera`
+              : 'Nenhum pedido pendente'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className={styles.refresh}
+          onClick={handleRefresh}
+          disabled={isLoading}
+        >
+          {isLoading ? 'Atualizando…' : 'Atualizar'}
+        </button>
+      </header>
+      <div className={styles.list}>
+        {isLoading && orders.length === 0 ? (
+          <p className={styles.feedback}>Carregando pedidos…</p>
+        ) : null}
+        {!isLoading && orders.length === 0 ? (
+          <p className={styles.feedback}>A fila está vazia no momento.</p>
+        ) : null}
+        <ul className={styles.items}>
+          {orders.map((order) => {
+            const isSelected = order.id === selectedOrderId;
+            const isProcessing = order.id === processingOrderId;
+            return (
+              <li key={order.id}>
+                <button
+                  type="button"
+                  className={isSelected ? styles.itemSelected : styles.item}
+                  onClick={(): void => handleSelect(order.id)}
+                  aria-current={isSelected}
+                >
+                  <div className={styles.itemHeader}>
+                    <span className={styles.orderId}>#{order.id}</span>
+                    <span className={styles.timestamp}>{formatTimestamp(order.createdAt)}</span>
+                  </div>
+                  <div className={styles.itemBody}>
+                    <span className={styles.customer}>{order.customer.name}</span>
+                    <span className={styles.total}>{formatCurrency(order.totals.total)}</span>
+                  </div>
+                  <div className={styles.itemFooter}>
+                    <span className={styles.count}>
+                      {order.items.length} item{order.items.length > 1 ? 's' : ''}
+                    </span>
+                    {isProcessing ? <span className={styles.processing}>Processando…</span> : null}
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default OrderList;

--- a/src/admin/state/AdminAuthContext.ts
+++ b/src/admin/state/AdminAuthContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export interface AdminAuthContextValue {
+  isAuthenticated: boolean;
+  expectedToken: string;
+  login(token: string): boolean;
+  logout(): void;
+}
+
+export const AdminAuthContext = createContext<AdminAuthContextValue | null>(null);

--- a/src/admin/state/AdminAuthProvider.tsx
+++ b/src/admin/state/AdminAuthProvider.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FC, ReactNode } from 'react';
+import { AdminAuthContext } from './AdminAuthContext';
+
+const STORAGE_KEY = 'admin-dashboard-token';
+const DEFAULT_ADMIN_TOKEN = 'admin';
+
+const readStoredToken = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.sessionStorage.getItem(STORAGE_KEY);
+};
+
+const storeToken = (token: string | null): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (token) {
+    window.sessionStorage.setItem(STORAGE_KEY, token);
+  } else {
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  }
+};
+
+const resolveExpectedToken = (): string => {
+  if (typeof import.meta === 'undefined') {
+    return DEFAULT_ADMIN_TOKEN;
+  }
+
+  const token = import.meta.env?.VITE_ADMIN_TOKEN;
+  if (typeof token === 'string' && token.trim().length > 0) {
+    return token;
+  }
+
+  return DEFAULT_ADMIN_TOKEN;
+};
+
+export const AdminAuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const expectedToken = useMemo<string>(() => resolveExpectedToken(), []);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(() => {
+    const storedToken = readStoredToken();
+    return storedToken === expectedToken;
+  });
+
+  useEffect((): void => {
+    const storedToken = readStoredToken();
+    setIsAuthenticated(storedToken === expectedToken);
+  }, [expectedToken]);
+
+  const login = useCallback(
+    (token: string): boolean => {
+      const sanitized = token.trim();
+      if (sanitized !== expectedToken) {
+        return false;
+      }
+
+      storeToken(expectedToken);
+      setIsAuthenticated(true);
+      return true;
+    },
+    [expectedToken],
+  );
+
+  const logout = useCallback((): void => {
+    storeToken(null);
+    setIsAuthenticated(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      isAuthenticated,
+      expectedToken,
+      login,
+      logout,
+    }),
+    [isAuthenticated, expectedToken, login, logout],
+  );
+
+  return <AdminAuthContext.Provider value={value}>{children}</AdminAuthContext.Provider>;
+};

--- a/src/admin/state/OrderQueueContext.ts
+++ b/src/admin/state/OrderQueueContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react';
+import type { OrderResponse } from '../../types/order';
+
+export interface OrderQueueContextValue {
+  orders: OrderResponse[];
+  selectedOrder: OrderResponse | null;
+  selectedOrderId: string | null;
+  isLoading: boolean;
+  isProcessing: boolean;
+  processingOrderId: string | null;
+  error: string | null;
+  refresh(): Promise<void>;
+  selectOrder(orderId: string | null): void;
+  accept(orderId: string): Promise<void>;
+  discard(orderId: string): Promise<void>;
+}
+
+export const OrderQueueContext = createContext<OrderQueueContextValue | null>(null);

--- a/src/admin/state/OrderQueueProvider.tsx
+++ b/src/admin/state/OrderQueueProvider.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import type { FC, ReactNode } from 'react';
+import type { OrderResponse } from '../../types/order';
+import { OrderCommandService } from '../../services/OrderCommandService';
+import { OrderRepository } from '../../services/OrderRepository';
+import { OrderQueueContext, type OrderQueueContextValue } from './OrderQueueContext';
+
+interface OrderQueueProviderProps {
+  repository: OrderRepository;
+  commandService: OrderCommandService;
+  children: ReactNode;
+}
+
+interface OrderQueueState {
+  orders: OrderResponse[];
+  selectedOrderId: string | null;
+  isLoading: boolean;
+  isProcessing: boolean;
+  processingOrderId: string | null;
+  error: string | null;
+}
+
+type OrderQueueAction =
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; orders: OrderResponse[] }
+  | { type: 'FETCH_FAILURE'; message: string }
+  | { type: 'SELECT_ORDER'; orderId: string | null }
+  | { type: 'PROCESS_START'; orderId: string }
+  | { type: 'PROCESS_FAILURE'; message: string }
+  | { type: 'PROCESS_END' }
+  | { type: 'REMOVE_ORDER'; orderId: string };
+
+const initialState: OrderQueueState = {
+  orders: [],
+  selectedOrderId: null,
+  isLoading: false,
+  isProcessing: false,
+  processingOrderId: null,
+  error: null,
+};
+
+const orderQueueReducer = (state: OrderQueueState, action: OrderQueueAction): OrderQueueState => {
+  switch (action.type) {
+    case 'FETCH_START':
+      return {
+        ...state,
+        isLoading: true,
+        error: null,
+      };
+    case 'FETCH_SUCCESS': {
+      const nextOrders = action.orders;
+      const nextSelectedId =
+        state.selectedOrderId && nextOrders.some((order) => order.id === state.selectedOrderId)
+          ? state.selectedOrderId
+          : nextOrders[0]?.id ?? null;
+      return {
+        ...state,
+        orders: nextOrders,
+        selectedOrderId: nextSelectedId,
+        isLoading: false,
+        error: null,
+      };
+    }
+    case 'FETCH_FAILURE':
+      return {
+        ...state,
+        isLoading: false,
+        error: action.message,
+      };
+    case 'SELECT_ORDER':
+      return {
+        ...state,
+        selectedOrderId: action.orderId,
+      };
+    case 'PROCESS_START':
+      return {
+        ...state,
+        isProcessing: true,
+        processingOrderId: action.orderId,
+        error: null,
+      };
+    case 'PROCESS_FAILURE':
+      return {
+        ...state,
+        error: action.message,
+      };
+    case 'PROCESS_END':
+      return {
+        ...state,
+        isProcessing: false,
+        processingOrderId: null,
+      };
+    case 'REMOVE_ORDER': {
+      const remaining = state.orders.filter((order) => order.id !== action.orderId);
+      const nextSelectedId =
+        state.selectedOrderId && remaining.some((order) => order.id === state.selectedOrderId)
+          ? state.selectedOrderId
+          : remaining[0]?.id ?? null;
+      return {
+        ...state,
+        orders: remaining,
+        selectedOrderId: nextSelectedId,
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export const OrderQueueProvider: FC<OrderQueueProviderProps> = ({
+  repository,
+  commandService,
+  children,
+}) => {
+  const [state, dispatch] = useReducer(orderQueueReducer, initialState);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    dispatch({ type: 'FETCH_START' });
+    try {
+      const orders = await repository.listPending();
+      dispatch({ type: 'FETCH_SUCCESS', orders });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Falha ao carregar pedidos.';
+      dispatch({ type: 'FETCH_FAILURE', message });
+    }
+  }, [repository]);
+
+  useEffect((): void => {
+    void refresh();
+  }, [refresh]);
+
+  const selectOrder = useCallback((orderId: string | null): void => {
+    dispatch({ type: 'SELECT_ORDER', orderId });
+  }, []);
+
+  const accept = useCallback(
+    async (orderId: string): Promise<void> => {
+      dispatch({ type: 'PROCESS_START', orderId });
+      try {
+        await commandService.acceptOrder(orderId);
+        dispatch({ type: 'REMOVE_ORDER', orderId });
+        void refresh();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Falha ao aceitar pedido.';
+        dispatch({ type: 'PROCESS_FAILURE', message });
+      } finally {
+        dispatch({ type: 'PROCESS_END' });
+      }
+    },
+    [commandService, refresh],
+  );
+
+  const discard = useCallback(
+    async (orderId: string): Promise<void> => {
+      dispatch({ type: 'PROCESS_START', orderId });
+      try {
+        await commandService.discardOrder(orderId);
+        dispatch({ type: 'REMOVE_ORDER', orderId });
+        void refresh();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Falha ao descartar pedido.';
+        dispatch({ type: 'PROCESS_FAILURE', message });
+      } finally {
+        dispatch({ type: 'PROCESS_END' });
+      }
+    },
+    [commandService, refresh],
+  );
+
+  const selectedOrder = useMemo<OrderResponse | null>(() => {
+    if (!state.selectedOrderId) {
+      return null;
+    }
+    return state.orders.find((order) => order.id === state.selectedOrderId) ?? null;
+  }, [state.orders, state.selectedOrderId]);
+
+  const value = useMemo<OrderQueueContextValue>(
+    () => ({
+      orders: state.orders,
+      selectedOrder,
+      selectedOrderId: state.selectedOrderId,
+      isLoading: state.isLoading,
+      isProcessing: state.isProcessing,
+      processingOrderId: state.processingOrderId,
+      error: state.error,
+      refresh,
+      selectOrder,
+      accept,
+      discard,
+    }),
+    [
+      state.orders,
+      selectedOrder,
+      state.selectedOrderId,
+      state.isLoading,
+      state.isProcessing,
+      state.processingOrderId,
+      state.error,
+      refresh,
+      selectOrder,
+      accept,
+      discard,
+    ],
+  );
+
+  return <OrderQueueContext.Provider value={value}>{children}</OrderQueueContext.Provider>;
+};

--- a/src/admin/state/useAdminAuth.ts
+++ b/src/admin/state/useAdminAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AdminAuthContext, type AdminAuthContextValue } from './AdminAuthContext';
+
+export const useAdminAuth = (): AdminAuthContextValue => {
+  const context = useContext(AdminAuthContext);
+  if (!context) {
+    throw new Error('useAdminAuth deve ser usado dentro de um AdminAuthProvider.');
+  }
+  return context;
+};

--- a/src/admin/state/useOrderQueue.ts
+++ b/src/admin/state/useOrderQueue.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { OrderQueueContext, type OrderQueueContextValue } from './OrderQueueContext';
+
+export const useOrderQueue = (): OrderQueueContextValue => {
+  const context = useContext(OrderQueueContext);
+  if (!context) {
+    throw new Error('useOrderQueue deve ser usado dentro de um OrderQueueProvider.');
+  }
+  return context;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,36 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.tsx';
+import AdminLogin from './admin/AdminLogin.tsx';
+import AdminProtectedRoute from './admin/AdminProtectedRoute.tsx';
+import Dashboard from './admin/Dashboard.tsx';
+import { AdminAuthProvider } from './admin/state/AdminAuthProvider.tsx';
 import './styles/base.css';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+  },
+  {
+    path: '/admin',
+    element: (
+      <AdminProtectedRoute>
+        <Dashboard />
+      </AdminProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/login',
+    element: <AdminLogin />,
+  },
+]);
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
-    <App />
+    <AdminAuthProvider>
+      <RouterProvider router={router} />
+    </AdminAuthProvider>
   </StrictMode>,
 );

--- a/src/services/OrderCommandService.ts
+++ b/src/services/OrderCommandService.ts
@@ -1,0 +1,104 @@
+import type { OrderStatus } from '../types/order';
+import { OrderRepository } from './OrderRepository';
+
+type EndpointBuilder = (orderId: string) => string;
+
+type RequestInitFactory = (status: OrderStatus) => RequestInit;
+
+interface OrderCommand {
+  execute(orderId: string): Promise<void>;
+}
+
+interface UpdateOrderStatusCommandOptions {
+  buildEndpoint: EndpointBuilder;
+  status: OrderStatus;
+  requestInitFactory: RequestInitFactory;
+}
+
+class UpdateOrderStatusCommand implements OrderCommand {
+  private readonly buildEndpoint: EndpointBuilder;
+
+  private readonly status: OrderStatus;
+
+  private readonly requestInitFactory: RequestInitFactory;
+
+  public constructor(options: UpdateOrderStatusCommandOptions) {
+    this.buildEndpoint = options.buildEndpoint;
+    this.status = options.status;
+    this.requestInitFactory = options.requestInitFactory;
+  }
+
+  public async execute(orderId: string): Promise<void> {
+    const endpoint = this.buildEndpoint(orderId);
+    const response = await fetch(endpoint, this.requestInitFactory(this.status));
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Falha ao atualizar pedido ${orderId}: ${response.status} ${
+          errorText || response.statusText
+        }`.trim(),
+      );
+    }
+  }
+}
+
+export interface OrderCommandServiceOptions {
+  repository: OrderRepository;
+  commandEndpoint?: string;
+  requestInitFactory?: RequestInitFactory;
+}
+
+export class OrderCommandService {
+  private readonly acceptCommand: OrderCommand;
+
+  private readonly discardCommand: OrderCommand;
+
+  public constructor(options: OrderCommandServiceOptions) {
+    const baseEndpoint = this.resolveBaseEndpoint(options);
+    const requestInitFactory =
+      options.requestInitFactory ?? OrderCommandService.createDefaultRequestFactory();
+    const endpointBuilder: EndpointBuilder = (orderId: string): string =>
+      `${baseEndpoint}/${encodeURIComponent(orderId)}`;
+
+    this.acceptCommand = new UpdateOrderStatusCommand({
+      buildEndpoint: endpointBuilder,
+      status: 'confirmed',
+      requestInitFactory,
+    });
+
+    this.discardCommand = new UpdateOrderStatusCommand({
+      buildEndpoint: endpointBuilder,
+      status: 'failed',
+      requestInitFactory,
+    });
+  }
+
+  public async acceptOrder(orderId: string): Promise<void> {
+    await this.acceptCommand.execute(orderId);
+  }
+
+  public async discardOrder(orderId: string): Promise<void> {
+    await this.discardCommand.execute(orderId);
+  }
+
+  private resolveBaseEndpoint(options: OrderCommandServiceOptions): string {
+    const rawEndpoint =
+      options.commandEndpoint ??
+      options.repository.getQueueEndpoint() ??
+      options.repository.getEndpoint();
+
+    return rawEndpoint.replace(/\/$/, '');
+  }
+
+  private static createDefaultRequestFactory(): RequestInitFactory {
+    return (status: OrderStatus): RequestInit => ({
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ status }),
+      cache: 'no-store',
+    });
+  }
+}

--- a/src/styles/admin/AdminLogin.module.css
+++ b/src/styles/admin/AdminLogin.module.css
@@ -1,0 +1,78 @@
+.wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: var(--bg);
+}
+
+.form {
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px;
+  border-radius: 20px;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--line);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: -8px 0 8px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  font-size: 1rem;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(255, 122, 0, 0.24);
+}
+
+.error {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(244, 67, 54, 0.12);
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
+.submit {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 0;
+  background: var(--brand);
+  color: #fff;
+  font-weight: 600;
+}
+
+.submit:hover {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 480px) {
+  .form {
+    padding: 24px;
+  }
+}

--- a/src/styles/admin/Dashboard.module.css
+++ b/src/styles/admin/Dashboard.module.css
@@ -1,0 +1,59 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 24px;
+  gap: 24px;
+  background: var(--bg);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.headingGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) 1fr;
+  gap: 24px;
+  flex: 1;
+  min-height: 0;
+}
+
+.error {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(244, 67, 54, 0.08);
+  color: #c62828;
+  border: 1px solid rgba(244, 67, 54, 0.18);
+}
+
+@media (max-width: 960px) {
+  .dashboard {
+    padding: 16px;
+  }
+
+  .columns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/admin/OrderDetails.module.css
+++ b/src/styles/admin/OrderDetails.module.css
@@ -1,0 +1,182 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--card);
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  padding: 24px;
+  gap: 16px;
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.status {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.status.pending,
+.status.queued {
+  background: rgba(255, 122, 0, 0.12);
+  color: var(--brand);
+  border-color: rgba(255, 122, 0, 0.32);
+}
+
+.status.confirmed {
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--ok);
+  border-color: rgba(22, 163, 74, 0.32);
+}
+
+.status.failed {
+  background: rgba(244, 67, 54, 0.12);
+  color: #c62828;
+  border-color: rgba(244, 67, 54, 0.32);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.sectionContent {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.sectionContentMuted {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.inlineNote {
+  margin-left: 8px;
+  color: var(--muted);
+}
+
+.items {
+  flex: 1;
+}
+
+.itemsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.item {
+  padding: 16px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+.itemHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.itemName {
+  font-weight: 600;
+}
+
+.itemTotal {
+  font-weight: 700;
+}
+
+.itemMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.summaryRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 1.1rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.accept,
+.discard {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 0;
+  font-weight: 600;
+}
+
+.accept {
+  background: var(--brand);
+  color: #fff;
+}
+
+.discard {
+  background: color-mix(in srgb, var(--fg) 12%, transparent);
+  color: var(--muted);
+}
+
+.accept:disabled,
+.discard:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  color: var(--muted);
+  height: 100%;
+}
+
+@media (max-width: 960px) {
+  .container {
+    min-height: 360px;
+  }
+}

--- a/src/styles/admin/OrderList.module.css
+++ b/src/styles/admin/OrderList.module.css
@@ -1,0 +1,122 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--card);
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.caption {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.refresh {
+  padding: 10px 16px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--brand);
+  color: #fff;
+  font-weight: 600;
+}
+
+.refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.item,
+.itemSelected {
+  width: 100%;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+}
+
+.itemSelected {
+  background: rgba(255, 122, 0, 0.12);
+}
+
+.itemHeader,
+.itemBody,
+.itemFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.orderId {
+  font-weight: 600;
+}
+
+.timestamp {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.customer {
+  font-weight: 600;
+}
+
+.total {
+  font-weight: 700;
+}
+
+.count {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.processing {
+  font-size: 0.875rem;
+  color: var(--brand);
+}
+
+.feedback {
+  margin: 0;
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+}
+
+@media (max-width: 960px) {
+  .container {
+    height: auto;
+    max-height: 380px;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate React Router to expose a protected /admin dashboard backed by an admin authentication provider and login form
- implement an order queue state layer plus typed OrderList/OrderDetails widgets that reuse the OrderRepository and a new OrderCommandService for accept/discard use cases
- extend the OrderRepository with pending order loading helpers and wire the new layout styling for the administrative experience

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0a099be308330acc2c2ca065260c9