### PR TITLE
Add admin login shortcut to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEventHandler, FC } from 'react';
+import { Link } from 'react-router-dom';
 import type { GeolocationStatus } from '../hooks/useGeolocation';
 import styles from '../styles/Header.module.css';
 
@@ -55,6 +56,13 @@ const Header: FC<HeaderProps> = ({
           <div className={styles.mark}>🍕</div>
           <div>Pizzaria Minutu’s</div>
         </div>
+        <Link
+          to="/admin/login"
+          className={styles.adminLink}
+          aria-label="Ir para login administrativo"
+        >
+          Área Admin
+        </Link>
         <button type="button" className={styles.iconButton} onClick={handleThemeClick} aria-label="Alternar tema">
           ◐
         </button>

--- a/src/styles/Header.module.css
+++ b/src/styles/Header.module.css
@@ -13,6 +13,35 @@
   gap: 10px;
 }
 
+.adminLink {
+  margin-left: auto;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--brand), var(--brand-2));
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.adminLink:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.14);
+}
+
+.adminLink:focus-visible {
+  outline: 2px solid var(--brand-2);
+  outline-offset: 2px;
+}
+
+.adminLink:active {
+  transform: translateY(0);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.18);
+}
+
 .iconButton {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## Summary
- add a dedicated admin login link to the header topbar for quick navigation
- style the admin link to match existing branding with accessible focus treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0ac46923c8330a763ea2ab2a948a8