### PR TITLE
Add order listing handler with in-memory store

### DIFF
--- a/src/mocks/handlers/orders.ts
+++ b/src/mocks/handlers/orders.ts
@@ -1,6 +1,44 @@
 import { http, HttpResponse, type HttpHandler } from 'msw';
 import type { OrderRequest, OrderResponse } from '../../types/order';
 
+type PendingOrderStatus = Extract<OrderResponse['status'], 'pending' | 'queued'>;
+
+const pendingStatusFilter: readonly PendingOrderStatus[] = ['pending', 'queued'];
+
+const filterByStatuses = (
+  orders: OrderResponse[],
+  statuses: readonly PendingOrderStatus[],
+): OrderResponse[] => {
+  const statusSet = new Set<OrderResponse['status']>(statuses);
+  return orders.filter((order) => statusSet.has(order.status));
+};
+
+const cloneOrder = (order: OrderResponse): OrderResponse =>
+  typeof structuredClone === 'function'
+    ? structuredClone(order)
+    : (JSON.parse(JSON.stringify(order)) as OrderResponse);
+
+const orderRepository = (() => {
+  const orders: OrderResponse[] = [];
+
+  return {
+    add(order: OrderResponse): void {
+      orders.push(cloneOrder(order));
+    },
+    list(request: Request): OrderResponse[] {
+      const url = new URL(request.url);
+      const statusParam = url.searchParams.get('status');
+      const snapshot = orders.map((order) => cloneOrder(order));
+
+      if (!statusParam) {
+        return snapshot;
+      }
+
+      return filterByStatuses(snapshot, pendingStatusFilter);
+    },
+  };
+})();
+
 const generateOrderId = (): string => {
   if (typeof globalThis.crypto?.randomUUID === 'function') {
     return globalThis.crypto.randomUUID();
@@ -40,6 +78,13 @@ export const orderHandlers: HttpHandler[] = [
     const orderRequest = (await request.json()) as OrderRequest;
     const responseBody = buildOrderResponse(orderRequest);
 
+    orderRepository.add(responseBody);
+
     return HttpResponse.json(responseBody, { status: 201 });
+  }),
+  http.get('/api/orders', ({ request }) => {
+    const responseBody = orderRepository.list(request);
+
+    return HttpResponse.json(responseBody, { status: 200 });
   }),
 ];


### PR DESCRIPTION
## Summary
- add an in-memory repository to persist mock orders and reuse buildOrderResponse metadata
- expose a GET /api/orders handler that filters pending and queued statuses while reading from the in-memory cache

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0b445144c8330abfb9e42f64812ad