### PR TITLE
Add checkout flow integration test

### DIFF
--- a/src/__tests__/checkout.test.tsx
+++ b/src/__tests__/checkout.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import App from '../App';
+import { OrderRepository } from '../services/OrderRepository';
+import { MemoryRouter } from 'react-router-dom';
+import type { OrderRequest, OrderResponse } from '../types/order';
+
+describe('Checkout flow', (): void => {
+  beforeAll((): void => {
+    if (!HTMLElement.prototype.animate) {
+      Object.defineProperty(HTMLElement.prototype, 'animate', {
+        value: vi.fn(),
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  afterEach((): void => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('should create an order and open WhatsApp with the summary', async (): Promise<void> => {
+    const createSpy = vi
+      .spyOn(OrderRepository.prototype, 'create')
+      .mockImplementation(async (order: OrderRequest): Promise<OrderResponse> => {
+        return {
+          id: 'order-123',
+          status: 'pending',
+          customer: order.customer,
+          items: order.items,
+          totals: order.totals,
+          address: order.address,
+          createdAt: new Date().toISOString(),
+          metadata: order.metadata,
+        };
+      });
+
+    const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    const addButtons = await screen.findAllByRole('button', { name: '+ Adicionar' });
+    fireEvent.click(addButtons[0]);
+
+    const confirmButton = await screen.findByRole('button', { name: '+ Adicionar ao carrinho' });
+    fireEvent.click(confirmButton);
+
+    const viewBagButton = await screen.findByRole('button', { name: /ver sacola/i });
+    fireEvent.click(viewBagButton);
+
+    const finalizeButton = await screen.findByRole('button', { name: /finalizar/i });
+    fireEvent.click(finalizeButton);
+
+    await waitFor((): void => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor((): void => {
+      expect(windowOpenSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totals: expect.objectContaining({
+          total: expect.any(Number),
+          count: expect.any(Number),
+        }),
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            productId: 'pz1',
+            quantity: 1,
+            selection: expect.objectContaining({
+              size: 'M',
+              crust: 'classic',
+            }),
+          }),
+        ]),
+        metadata: expect.objectContaining({
+          channel: 'web',
+        }),
+      }),
+    );
+
+    const [orderRequest] = createSpy.mock.calls[0] as [OrderRequest];
+    expect(orderRequest.totals.total).toBeCloseTo(34.9, 2);
+    expect(orderRequest.totals.count).toBe(1);
+
+    const metadata: Record<string, unknown> = (orderRequest.metadata ?? {}) as Record<string, unknown>;
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        channel: 'web',
+        addressText: expect.any(String),
+      }),
+    );
+
+    const [checkoutUrl] = windowOpenSpy.mock.calls[0] ?? [];
+    expect(typeof checkoutUrl).toBe('string');
+    expect(checkoutUrl).toContain('https://wa.me/');
+    expect(checkoutUrl).toContain('order-123');
+    expect(checkoutUrl).toContain('Margherita x1');
+    expect(checkoutUrl).toContain('Total:');
+    expect(windowOpenSpy).toHaveBeenCalledWith(checkoutUrl, '_blank');
+  });
+});


### PR DESCRIPTION
## Summary
- add an integration test for the checkout flow covering order submission and WhatsApp redirect
- mock browser-specific APIs to keep the flow deterministic during testing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0b5b192f88330a9b99b235dc5ac3b