### PR TITLE
feat: centralize messaging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,19 @@
 - Run `npm run dev` to start the Vite development server. When `import.meta.env.DEV` is true (the default for `npm run dev`), the application automatically loads the [Mock Service Worker](https://mswjs.io/) and intercepts calls to `/api/orders`, returning structured `OrderResponse` payloads with generated identifiers and timestamps. This keeps the existing Repository pattern untouched, so you can seamlessly switch between mock and real backends.
 - To temporarily connect to a real backend while still in development, define either `VITE_ORDERS_ENDPOINT` or `VITE_ORDERS_QUEUE_ENDPOINT` in a `.env.development` file (or via your shell) before launching Vite. When these variables are present, the repository targets those URLs and the MSW worker continues to bypass unhandled requests.
 
+### Configuring the WhatsApp order channel
+
+- `VITE_WHATSAPP_NUMBER` controls the phone number used when the checkout flow opens `wa.me`. Provide the value as digits only (e.g., `5581999999999`). The runtime strips non-numeric characters and falls back to the demo number when the value is missing or too short.
+- For ad-hoc testing, export the variable inline alongside any script, such as `VITE_WHATSAPP_NUMBER="5581999999999" npm run dev` or `VITE_WHATSAPP_NUMBER="5581999999999" npm run preview`.
+- Persist the configuration in `.env.development`, `.env.production`, or the environment section of your hosting provider when the same number should be reused across deploys.
+
 ## Configuring real endpoints for production
 
 Before building or deploying, point the application to your production backend by setting:
 
 - `VITE_ORDERS_ENDPOINT` with the absolute URL that persists new orders.
 - `VITE_ORDERS_QUEUE_ENDPOINT` when you want new orders to be queued instead of persisted directly.
+- `VITE_WHATSAPP_NUMBER` to override the WhatsApp destination for production checkouts.
 
 You can define the variables in `.env.production`, export them inline (e.g., `VITE_ORDERS_ENDPOINT="https://api.example.com/orders" npm run build`), or configure them through your hosting provider.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import CategoryTabs from './components/CategoryTabs';
 import Header from './components/Header';
 import MenuList from './components/MenuList';
 import ProductModal from './components/ProductModal';
-import { CATEGORIES, PRODUCTS, WHATSAPP_NUMBER } from './data/menu';
+import { getMessagingConfig } from './config/messaging';
+import { CATEGORIES, PRODUCTS } from './data/menu';
 import { useGeolocation } from './hooks/useGeolocation';
 import { useLocalStorageCart } from './hooks/useLocalStorageCart';
 import type { CartSelection, CartTotals, Product } from './types/menu';
@@ -15,6 +16,8 @@ import { OrderRepository } from './services/OrderRepository';
 import { buildCartLines, createCartKey } from './utils/cart';
 import { formatCurrency } from './utils/format';
 import styles from './styles/App.module.css';
+
+const { whatsappNumber } = getMessagingConfig();
 
 const App: FC = () => {
   const [activeCategory, setActiveCategory] = useState<string>(CATEGORIES[0]?.name ?? '');
@@ -232,7 +235,7 @@ const App: FC = () => {
       const orderResponse = await orderRepository.create(orderRequest);
       const orderReference = orderResponse.id ? `Pedido #${orderResponse.id}%0A%0A` : '';
       const message = `Pizzaria Minutu's - novo pedido%0A%0A${orderReference}${linesSummary}%0A%0ATotal: ${totalText}%0AEntrega: ${encodedAddress}%0A`;
-      const checkoutUrl = `https://wa.me/${WHATSAPP_NUMBER}?text=${message}`;
+      const checkoutUrl = `https://wa.me/${whatsappNumber}?text=${message}`;
       window.open(checkoutUrl, '_blank');
       clear();
       setIsCartOpen(false);

--- a/src/__tests__/checkout.test.tsx
+++ b/src/__tests__/checkout.test.tsx
@@ -1,9 +1,22 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MessagingConfig } from '../config/messaging';
 import App from '../App';
 import { OrderRepository } from '../services/OrderRepository';
 import { MemoryRouter } from 'react-router-dom';
 import type { OrderRequest, OrderResponse } from '../types/order';
+
+const { whatsappNumberMock } = vi.hoisted((): { whatsappNumberMock: string } => ({
+  whatsappNumberMock: '5599988877766',
+}));
+
+vi.mock('../config/messaging', (): typeof import('../config/messaging') => {
+  const messagingConfig: MessagingConfig = { whatsappNumber: whatsappNumberMock };
+  return {
+    getMessagingConfig: (): MessagingConfig => messagingConfig,
+    resolveWhatsappNumber: (): string => messagingConfig.whatsappNumber,
+  };
+});
 
 describe('Checkout flow', (): void => {
   beforeAll((): void => {
@@ -101,7 +114,7 @@ describe('Checkout flow', (): void => {
 
     const [checkoutUrl] = windowOpenSpy.mock.calls[0] ?? [];
     expect(typeof checkoutUrl).toBe('string');
-    expect(checkoutUrl).toContain('https://wa.me/');
+    expect(checkoutUrl).toContain(`https://wa.me/${whatsappNumberMock}`);
     expect(checkoutUrl).toContain('order-123');
     expect(checkoutUrl).toContain('Margherita x1');
     expect(checkoutUrl).toContain('Total:');

--- a/src/config/messaging.ts
+++ b/src/config/messaging.ts
@@ -1,0 +1,40 @@
+const DEFAULT_WHATSAPP_NUMBER = '5561985007483';
+const MIN_WHATSAPP_NUMBER_LENGTH = 8;
+
+export interface MessagingEnv {
+  readonly VITE_WHATSAPP_NUMBER?: string | undefined;
+}
+
+export interface MessagingConfig {
+  readonly whatsappNumber: string;
+}
+
+const sanitizeWhatsappNumber = (value: string | undefined | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const digitsOnly = value.replace(/\D/gu, '');
+  if (digitsOnly.length < MIN_WHATSAPP_NUMBER_LENGTH) {
+    return null;
+  }
+
+  return digitsOnly;
+};
+
+export const resolveWhatsappNumber = (
+  env: MessagingEnv = import.meta.env as MessagingEnv,
+): string => {
+  const sanitized = sanitizeWhatsappNumber(env.VITE_WHATSAPP_NUMBER ?? null);
+  if (sanitized) {
+    return sanitized;
+  }
+
+  return DEFAULT_WHATSAPP_NUMBER;
+};
+
+const messagingConfig: MessagingConfig = Object.freeze({
+  whatsappNumber: resolveWhatsappNumber(),
+});
+
+export const getMessagingConfig = (): MessagingConfig => messagingConfig;

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -1,7 +1,5 @@
 import type { Category, Product, ProductOptions } from '../types/menu';
 
-export const WHATSAPP_NUMBER = '5561985007483';
-
 const createEmojiImage = (emoji: string, background: string): string => {
   const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='100%' height='100%' rx='24' fill='${background}'/><text x='50%' y='52%' text-anchor='middle' font-family='system-ui' font-size='20'>${emoji}</text></svg>`;
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;


### PR DESCRIPTION
## Summary
- add a messaging configuration module that sanitizes environment-provided WhatsApp numbers with a safe fallback
- wire the checkout flow to consume the shared configuration instead of menu constants
- document the new VITE_WHATSAPP_NUMBER variable and update checkout tests to mock the configurable number

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0c52792a08330998c89b8ca24c77c